### PR TITLE
Custom Context propagator

### DIFF
--- a/examples/opentelemetry-web/examples/xml-http-request/index.js
+++ b/examples/opentelemetry-web/examples/xml-http-request/index.js
@@ -35,10 +35,12 @@ class MyContextPropagator extends TextMapPropagator {
         const traceParent = this.buildTraceparent(spanContext);
         carrier.body = carrier.body.replaceAll(TRACEPARENT_PLACEHOLDER, traceParent);
       }
-    } else {
-      // use the default W3CTraceContextPropagator
-      this._w3cPropagator.inject(context, carrier, setter);
     }
+    if (typeof carrier.headers === 'object' && carrier.hasOwnProperty('headers')) {
+      // use the default W3CTraceContextPropagator
+      this._w3cPropagator.inject(context, carrier.headers, setter);
+    }
+
   }
 
   extract(context, carrier, getter) {

--- a/examples/opentelemetry-web/examples/xml-http-request/index.js
+++ b/examples/opentelemetry-web/examples/xml-http-request/index.js
@@ -31,7 +31,7 @@ class MyContextPropagator extends TextMapPropagator {
       return;
 
     if (typeof carrier.body === 'string' && carrier.hasOwnProperty('body')) {
-      if (args[0].includes(TRACEPARENT_PLACEHOLDER)) {
+      if (carrier.body.includes(TRACEPARENT_PLACEHOLDER)) {
         const traceParent = this.buildTraceparent(spanContext);
         carrier.body = carrier.body.replaceAll(TRACEPARENT_PLACEHOLDER, traceParent);
       }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -508,9 +508,14 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
               if (addContextToHeaders) {
                 plugin._addHeaders(this, spanUrl);
               } else {
-                let bodyWrapper = {body: args[0]};
-                api.propagation.inject(api.context.active(), bodyWrapper);
-                args[0] = bodyWrapper.body;
+                const headers: { [key: string]: unknown } = {};
+                let carrier = {body: args[0], headers: headers};
+                api.propagation.inject(api.context.active(), carrier);
+
+                args[0] = carrier.body;
+                Object.keys(headers).forEach(key => {
+                  this.setRequestHeader(key, String(headers[key]));
+                });
               }
               plugin._addResourceObserver(this, spanUrl);
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -504,8 +504,16 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
                   xhrMem.createdResources.observer.disconnect();
                 }
               };
-              plugin._addHeaders(this, spanUrl);
+              let addContextToHeaders = false;
+              if (addContextToHeaders) {
+                plugin._addHeaders(this, spanUrl);
+              } else {
+                let bodyWrapper = {body: args[0]};
+                api.propagation.inject(api.context.active(), bodyWrapper);
+                args[0] = bodyWrapper.body;
+              }
               plugin._addResourceObserver(this, spanUrl);
+
             }
           );
         }


### PR DESCRIPTION
that puts the trace context into http request body instead of headers. 
Prototype for demo.